### PR TITLE
Added admin navbar

### DIFF
--- a/app/views/shared/_header.slim
+++ b/app/views/shared/_header.slim
@@ -1,18 +1,15 @@
 header
   nav.navbar.navbar-default.navbar-fixed-top
-    /*.top-menu.top-menu-inverse
-      .container
-        p
-          span.right
-            - if user_signed_in?
-              = link_to 'My Account', users_path
-              = link_to 'Log Out', destroy_user_session_path, method: :delete
-              = link_to 'shopping-cart.html', class: 'shopping-cart'
-                i.fa.fa-shopping-cart
-                span.cart-badge 2
-            - else
-              = link_to 'Sign Up', new_user_registration_path
-              = link_to 'Log In', new_user_session_path*/
+    - if user_signed_in? && current_user.admin?
+      .top-menu.top-menu-inverse
+        .container
+          p
+            span.space-left
+            span.right
+              = link_to 'Orders', admin_orders_path
+              = link_to 'Landing Pages', admin_landing_pages_path
+              = link_to destroy_user_session_path, method: :delete
+                i.fa.fa-sign-out
     .container
       .navbar-header
         button.navbar-toggle.collapsed data-target='.navbar-collapse' data-toggle='collapse' type='button'


### PR DESCRIPTION
I put the thin black navbar back, but only if you're logged in as an admin. Also has direct links to the "orders" and "landing page" paths to make it easier to CRUD those. 

Finally, I think it's helpful to have this as a visual indicator that "oh, i'm logged in as admin!" instead of thinking you're logged in when you're really not.

![screen shot 2017-12-06 at 5 28 55 pm](https://user-images.githubusercontent.com/5170247/33694087-02f50d4a-daab-11e7-9385-30a9a9baec88.png)
